### PR TITLE
Change ngx.req.udp_socket() to ngx.req.socket() as the api changed

### DIFF
--- a/lib/resty/tftp/server.lua
+++ b/lib/resty/tftp/server.lua
@@ -13,7 +13,7 @@ local op = {
 }
 
 _M.serve = function(path)
-    local sock = ngx.req.udp_socket()
+    local sock = ngx.req.socket()
     if not sock then
         return ngx.log(ngx.WARN, "no socket")
     end


### PR DESCRIPTION
As visible in https://github.com/openresty/lua-nginx-module#nginx-api-for-lua the ngx.req lost the "udp_socket" function and instead has the compatible "socket" function.

Failure when using with udp_socket:

`server.lua:16: attempt to call field 'udp_socket' (a nil value)`

Tested with openresty/1.21.4.1 
Unknown to me when the change happened.